### PR TITLE
Avoid updating _at attribute when it's already set to true

### DIFF
--- a/lib/bool_at/macro.rb
+++ b/lib/bool_at/macro.rb
@@ -19,7 +19,7 @@ module BoolAt
           # Changes dirty state in virtual attribute
           define_method setter do |value|
             super(value)
-            send(at_setter, self[attr] ? Time.now : nil)
+            send(at_setter, self[attr] ? self[at_attribute] || Time.now : nil)
           end
 
           define_method attr do

--- a/spec/bool_at/macro_spec.rb
+++ b/spec/bool_at/macro_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe BoolAt::Macro do
         post.published = false
         expect(post.published?).to be false
       end
+
+      it "keep time if already set" do
+        past_date = 2.days.ago.to_time
+        post = Post.new(published_at: past_date)
+        post.published = true
+        expect(post.published?).to be true
+        expect(post.published_at).to be past_date
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In an instance of bool_at we have two main attributes: the boolean and the _at datetime. I visualise the _at attribute as the moment the field was marked as `true` after being on a `false` state. The actual behaviour is the opposite: if the boolean attribute have `true` as value and is updated again with `true` value, the `_at` attribute is being reset.
This situation could be misleading because, for example: every submitted edit form with the boolean field unchanged and with `true` value is going to update the `_at` attribute.

In this PR scope:
[X] Kept `_at` attribute value, if boolean one have `true` as previous value and get an update with same value
[X] Added specs to test this case

The solution was faced this way because I couldn't imagine any situation were the existent situation was expected. If there's any situation were it's required we could modify this PR to add an extra option to `bool_at` definition to define the behaviour on unchanged update and keep two behaviours on demand.

Thanks in advance. Amazing gem!